### PR TITLE
remove duplicate "Infrastructure as code"

### DIFF
--- a/plumber/yaml/faq.yaml
+++ b/plumber/yaml/faq.yaml
@@ -28,7 +28,6 @@ What skills do I need to become a Data Engineer?:
   - "⦁ Scripting language (Python, Java, or Scala)"
   - "⦁ Indexing & Query Optimization"
   - "⦁ Cloud platform (Amazon Web Services, Microsoft Azure, or Google Cloud Platform)"
-  - "⦁ Infrastructure as code"
   - "⦁ Batch Data Processing"
   - "⦁ Relational Database"
   - "⦁ Non-relational Database"


### PR DESCRIPTION
removes the extra "Infrastructure as code" from the faq